### PR TITLE
Fix/remaining life table

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -118,7 +118,7 @@ export default function Home() {
             <Button
               variant="contained"
               onClick={() => setShowModal(true)}
-              sx={{ marginTop: "1rem" }}
+              sx={{ marginTop: "1rem 0" }}
             >
               情報を設定
             </Button>

--- a/frontend/src/pages/persons/index.tsx
+++ b/frontend/src/pages/persons/index.tsx
@@ -14,11 +14,7 @@ import BackLink from "../../../components/BackLink";
 import PageHead from "../../../components/PageHead";
 import { useRecoilValue } from "recoil";
 import userAtom from "../../../recoil/atom/userAtoms";
-import { useRouter } from "next/router";
 import ProtectRoute from "../../../components/ProtectRoute";
-
-// CSSインポート
-import styles from "../../styles/persons/indexStyle.module.css";
 
 type personData = {
   id: number;
@@ -32,8 +28,6 @@ type personData = {
 const Persons = () => {
   const [persons, setPersons] = useState<personData[]>();
   const user = useRecoilValue(userAtom);
-
-  const router = useRouter();
 
   useEffect(() => {
     const setPersonData = async () => {
@@ -117,15 +111,15 @@ const Persons = () => {
           <title>余命一覧</title>
         </PageHead>
         {persons && (
-          <Container>
-            <Button
-              href="/persons/create"
-              variant="contained"
-              sx={{ marginTop: "1rem" }}
-            >
-              新規登録
-            </Button>
+          <Container maxWidth="md">
             <Box>
+              <Button
+                href="/persons/create"
+                variant="contained"
+                sx={{ margin: "1rem 0" }}
+              >
+                新規登録
+              </Button>
               <DataGrid
                 columns={cols}
                 rows={persons}

--- a/frontend/src/styles/indexStyle.module.css
+++ b/frontend/src/styles/indexStyle.module.css
@@ -4,10 +4,6 @@
   flex-direction: column;
 }
 
-.button {
-  margin-top: 1rem;
-}
-
 .personInfo {
   display: flex;
   align-items: center;


### PR DESCRIPTION
#6 

## 対応内容
 - 余命一覧のContainerにmaxWidth="md"を指定した。
   - ヘッダーにも同じコンポーネントを指定しているため、幅が統一された表示になる。