### PR TITLE
余命一覧の余命にソート機能を追加

### DIFF
--- a/backend/functions/getRemainTimeForSecond.js
+++ b/backend/functions/getRemainTimeForSecond.js
@@ -1,0 +1,35 @@
+const { PrismaClient } = require("@prisma/client");
+
+const prisma = new PrismaClient();
+
+const dateToSeconds = (date) => {
+  return Math.floor(date.getTime() / 1000);
+};
+
+const ageToSeconds = (age) => {
+  return age * 365 * 24 * 60 * 60;
+};
+
+const getRemainTimeForSeconds = async (sex, birthDate) => {
+  // 生年月日をDate型で取得→秒に変換
+  const birthDateInSeconds = dateToSeconds(birthDate);
+
+  // 現在年月日を秒で取得
+  const currentDateTimeInSeconds = Math.floor(Date.now() / 1000);
+
+  // 年齢を秒で算出
+  const ageInSeconds = currentDateTimeInSeconds - birthDateInSeconds;
+
+  // 平均寿命を取得→秒に変換
+  const currentYear = new Date().getFullYear();
+  const lifespan = await prisma.averageLife.findUnique({
+    where: { sex_year: { sex, year: String(currentYear - 1) } },
+  });
+  const averageLifespan = lifespan.age;
+  const averageLifespanInSeconds = ageToSeconds(averageLifespan);
+
+  // 余命(秒)を返却
+  return averageLifespanInSeconds - ageInSeconds;
+};
+
+module.exports = getRemainTimeForSeconds;


### PR DESCRIPTION
#16 

## 対応内容
 - 余命一覧の「余命」にソート機能を追加
   - 余命一覧画面に遷移時、各人物情報と共に、余命の秒数を取得し、この値を比較することでソートを実現。