### PR TITLE
人物情報の登録上限を追加

### DIFF
--- a/backend/routers/persons.js
+++ b/backend/routers/persons.js
@@ -60,6 +60,25 @@ router.get("/findAll", isAuthenticated, async (req, res) => {
   }
 });
 
+router.get("/findAllCount", isAuthenticated, async (req, res) => {
+  try {
+    const personsCount = await prisma.person.count({
+      where: { userId: req.userId },
+    });
+
+    // すでに10件以上の登録がある場合、エラー
+    if (personsCount >= 10) {
+      return res.status(403).json({
+        message: "10件以上の登録はできません",
+      });
+    }
+
+    res.status(200).json({ personsCount });
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+});
+
 router.post("/create", isAuthenticated, async (req, res) => {
   try {
     // バリデーション

--- a/frontend/src/pages/persons/create.tsx
+++ b/frontend/src/pages/persons/create.tsx
@@ -11,7 +11,7 @@ import {
   Typography,
 } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import apiClient from "../../lib/apiClient";
 import { useRouter } from "next/router";
 import BackLink from "../../../components/BackLink";
@@ -36,6 +36,20 @@ const CreatePersonData = () => {
 
   // エラー表示
   const [validationErrors, setValidationErrors] = useState<string[]>([]);
+
+  // 登録件数を確認
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    const getPersonsCount = async () => {
+      await apiClient.get("/persons/findAllCount").catch((err) => {
+        console.log("err: ", err);
+        handleErrorResponse(err);
+        router.push("/persons");
+      });
+    };
+
+    getPersonsCount();
+  }, []);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -65,6 +79,10 @@ const CreatePersonData = () => {
       case 500:
         alert("サーバで問題が発生しました。\nもう一度やり直してください。");
         router.push("/persons/create");
+        break;
+      case 403:
+        console.log("通過");
+        alert(err.response.data.message);
         break;
       case 400:
         setValidationErrors(err.response.data.messages);


### PR DESCRIPTION
#36 

## 内容
 - 登録できる人物情報を10件に制限
 - 10件以上登録された状態で登録画面に移動すると、アラート表示とともに余命一覧画面に遷移する。