### PR TITLE
Fix/rename signin to fetchuser

### DIFF
--- a/frontend/src/lib/authHelpers.ts
+++ b/frontend/src/lib/authHelpers.ts
@@ -1,7 +1,7 @@
 import apiClient from "./apiClient";
 import nookies from "nookies";
 
-export const signin = async (setUser) => {
+export const fetchUser = async (setUser) => {
   try {
     // サインイン時、ユーザーをセット
     apiClient

--- a/frontend/src/pages/signin.tsx
+++ b/frontend/src/pages/signin.tsx
@@ -6,15 +6,14 @@ import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
 import apiClient from "../lib/apiClient";
 import { useRouter } from "next/router";
-// import { useAuth } from "../context/auth";
 import PageHead from "../../components/PageHead";
 import HomeLink from "../../components/HomeLink";
 import { useSetRecoilState } from "recoil";
 import userAtom from "../../recoil/atom/userAtoms";
-import { signin } from "../lib/authHelpers";
 
 // CSSインポート
 import styles from "../styles/common.module.css";
+import { fetchUser } from "../lib/authHelpers";
 
 export default function SignIn() {
   // アカウント情報
@@ -29,8 +28,6 @@ export default function SignIn() {
 
   const router = useRouter();
 
-  // const { signin } = useAuth();
-
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     try {
@@ -40,8 +37,8 @@ export default function SignIn() {
           email,
           password,
         })
-        .then((res) => {
-          signin(setUser);
+        .then(() => {
+          fetchUser(setUser);
           router.push("/");
         })
         .catch((err) => {


### PR DESCRIPTION
#26 
## 内容
 - 関数名signinをfetchUserに変更
 - 実際のログイン処理はサーバの/auth/signinで実行されており、本関数はその後のuser情報取得をしている。