### PR TITLE
Fix/top page split

### DIFF
--- a/backend/routers/auth.js
+++ b/backend/routers/auth.js
@@ -4,6 +4,7 @@ const bcrypt = require("bcrypt");
 const jwt = require("jsonwebtoken");
 const signupSchema = require("../validators/signupSchema");
 const signinSchema = require("../validators/signinSchema");
+const isAuthenticated = require("../middlewares/isAuthenticated");
 
 const prisma = new PrismaClient();
 
@@ -109,6 +110,19 @@ router.post("/signin", async (req, res) => {
   } catch (err) {
     return res.status(500).json({ message: err.message });
   }
+});
+
+router.get("/clearCookie", async (req, res) => {
+  // Cookieの削除のレスポンスを生成
+  res.clearCookie("auth_token", {
+    httpOnly: true,
+    secure: true,
+    sameSite: "none",
+    path: "/",
+  });
+
+  // ログイン画面にリダイレクト
+  return res.status(200).json({ message: "Cooki削除成功" });
 });
 
 module.exports = router;

--- a/backend/routers/persons.js
+++ b/backend/routers/persons.js
@@ -60,7 +60,7 @@ router.get("/findAll", isAuthenticated, async (req, res) => {
   }
 });
 
-router.get("/findAllCount", isAuthenticated, async (req, res) => {
+router.get("/checkCount", isAuthenticated, async (req, res) => {
   try {
     const personsCount = await prisma.person.count({
       where: { userId: req.userId },

--- a/frontend/components/Navbar.tsx
+++ b/frontend/components/Navbar.tsx
@@ -1,5 +1,6 @@
 // React & Next.js
 import React, { useState } from "react";
+import { useRouter } from "next/router";
 import Image from "next/image";
 import Link from "next/link";
 
@@ -14,6 +15,7 @@ import { signout } from "../src/lib/authHelpers";
 import {
   AppBar,
   Box,
+  Button,
   Container,
   IconButton,
   List,
@@ -34,7 +36,12 @@ const buttonStyle = {
 };
 
 const Navbar = () => {
+  const router = useRouter();
+
+  // Drower スイッチ
   const [open, setOpen] = useState<boolean>(false);
+
+  // 共有情報
   const [user, setUser] = useRecoilState(userAtom);
 
   // メニューの切り替え
@@ -45,9 +52,9 @@ const Navbar = () => {
     setOpen(false);
   };
 
-  const handleSignout = () => {
-    signout(setUser);
+  const handleSignout = async () => {
     handleDrawerClose();
+    await signout(setUser, router);
   };
 
   const handleMypage = () => {
@@ -62,6 +69,16 @@ const Navbar = () => {
     handleDrawerClose();
   };
 
+  const handleLogoClick = () => {
+    if (user) {
+      // ログイン済みの場合、"/mypage"に遷移
+      router.push("/mypage");
+    } else {
+      // 未ログインの場合、"/"に遷移
+      router.push("/");
+    }
+  };
+
   return (
     <AppBar
       component="header"
@@ -71,14 +88,14 @@ const Navbar = () => {
       <Container maxWidth="md">
         <Box className={styles.headerContainer}>
           <Box component="h1">
-            <Link href="/">
+            <Button onClick={handleLogoClick}>
               <Image
                 src="/logo.png"
                 width={180}
                 height={40}
                 alt="RemainChecker"
               />
-            </Link>
+            </Button>
           </Box>
           <List component="nav" className={styles.listGroup}>
             <ListItem disablePadding>
@@ -99,12 +116,18 @@ const Navbar = () => {
                   sx={{ display: { xs: "none", md: "block" } }}
                 >
                   <div style={{ display: "flex" }}>
-                    <Link href={`/signin`} style={{ textDecoration: "none" }}>
+                    <Link
+                      href={`/auth/signin`}
+                      style={{ textDecoration: "none" }}
+                    >
                       <ListItemButton sx={buttonStyle}>
                         <ListItemText primary={`ログイン`} />
                       </ListItemButton>
                     </Link>
-                    <Link href={`/signup`} style={{ textDecoration: "none" }}>
+                    <Link
+                      href={`/auth/signup`}
+                      style={{ textDecoration: "none" }}
+                    >
                       <ListItemButton sx={buttonStyle}>
                         <ListItemText primary={`サインアップ`} />
                       </ListItemButton>
@@ -118,12 +141,18 @@ const Navbar = () => {
                 sx={{ display: { xs: "none", md: "block" } }}
               >
                 <div style={{ display: "flex" }}>
-                  <Link href={`/signin`} style={{ textDecoration: "none" }}>
+                  <Link
+                    href={`/auth/signin`}
+                    style={{ textDecoration: "none" }}
+                  >
                     <ListItemButton sx={buttonStyle} onClick={handleSignout}>
                       <ListItemText primary={`サインアウト`} />
                     </ListItemButton>
                   </Link>
-                  <Link href={`/mypage`} style={{ textDecoration: "none" }}>
+                  <Link
+                    href={`/mypage/setting`}
+                    style={{ textDecoration: "none" }}
+                  >
                     <ListItemButton sx={buttonStyle}>
                       <ListItemText primary={`ユーザ設定`} />
                     </ListItemButton>
@@ -147,13 +176,13 @@ const Navbar = () => {
           {!user ? (
             <>
               <ListItem disablePadding sx={{ display: "block" }}>
-                <Link href={`/signin`} style={{ textDecoration: "none" }}>
+                <Link href={`/auth/signin`} style={{ textDecoration: "none" }}>
                   <ListItemButton sx={buttonStyle} onClick={handleSignin}>
                     <ListItemText primary={`ログイン`} />
                   </ListItemButton>
                 </Link>
 
-                <Link href={`/signup`} style={{ textDecoration: "none" }}>
+                <Link href={`/auth/signup`} style={{ textDecoration: "none" }}>
                   <ListItemButton sx={buttonStyle} onClick={handleSignup}>
                     <ListItemText primary={`サインアップ`} />
                   </ListItemButton>
@@ -163,7 +192,7 @@ const Navbar = () => {
           ) : (
             <>
               <ListItem disablePadding sx={{ display: "block" }}>
-                <Link href={`/signin`} style={{ textDecoration: "none" }}>
+                <Link href={`/auth/signin`} style={{ textDecoration: "none" }}>
                   <ListItemButton sx={buttonStyle} onClick={handleSignout}>
                     <ListItemText primary={`サインアウト`} />
                   </ListItemButton>

--- a/frontend/components/ProtectPersonPage.tsx
+++ b/frontend/components/ProtectPersonPage.tsx
@@ -23,7 +23,7 @@ const ProtectPersonPage: React.FC<ProtectPersonPageProps> = ({
 
   // userが存在しない場合、ログイン画面にリダイレクト
   if (!user) {
-    router.push("/signin");
+    router.push("/auth/signin");
     return null;
   }
 

--- a/frontend/components/ProtectRoute.tsx
+++ b/frontend/components/ProtectRoute.tsx
@@ -18,7 +18,7 @@ const ProtectRoute: React.FC<{ user: userType; children: ReactNode }> = ({
 
   // userが存在しない場合、ログイン画面にリダイレクト
   if (!user) {
-    router.push("/signin");
+    router.push("/auth/signin");
     return;
   }
 

--- a/frontend/src/context/auth.tsx
+++ b/frontend/src/context/auth.tsx
@@ -34,22 +34,24 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   /* eslint-disable react-hooks/exhaustive-deps */
   useEffect(() => {
     const fetchData = async () => {
-      // 認証tokenを取得
-      const token = document.cookie;
-
-      if (Object.keys(token).length !== 0) {
-        // tokenに応じたuserをセット
-        try {
-          const res = await apiClient.get("/users/find");
+      // ユーザ認証
+      await apiClient
+        .get("users/find")
+        .then((res) => {
           setUser(res.data.user);
-        } catch (err) {
-          // tokenに応じたuserを取得できない場合、認証情報に異常がある判断してサインアウトする
+
+          // ログイン状態でトップページに移動した場合、マイページに移動
+          if (router.asPath === "/") {
+            router.push("/mypage");
+          }
+        })
+        .catch(() => {
           alert(
             "システムとの通信が切断されました。\nログインからやり直してください。",
           );
-          token ? signout(setUser) : router.push("/");
-        }
-      }
+          signout(setUser, router);
+        });
+
       setIsLoading(false);
     };
 

--- a/frontend/src/lib/authHelpers.ts
+++ b/frontend/src/lib/authHelpers.ts
@@ -1,7 +1,6 @@
 import apiClient from "./apiClient";
-import nookies from "nookies";
 
-export const fetchUser = async (setUser) => {
+export const fetchUser = async (setUser, router) => {
   try {
     // サインイン時、ユーザーをセット
     apiClient
@@ -11,11 +10,11 @@ export const fetchUser = async (setUser) => {
       })
       .catch((err) => {
         handleErrorResponse(err);
-        signout(setUser);
+        signout(setUser, router);
       });
   } catch (err) {
     alert("予期しないエラーが発生しました\nもう一度やり直してください");
-    signout(setUser);
+    signout(setUser, router);
   }
 };
 
@@ -32,7 +31,13 @@ const handleErrorResponse = (err) => {
   }
 };
 
-export const signout = (setUser) => {
-  nookies.destroy(null, "auth_token");
+export const signout = async (setUser, router) => {
+  // Cookie削除
+  await apiClient.get("/auth/clearCookie");
+
+  // ユーザ情報削除
   setUser(null);
+
+  // ログイン画面に遷移
+  router.push("/auth/signin");
 };

--- a/frontend/src/lib/errorHandler.ts
+++ b/frontend/src/lib/errorHandler.ts
@@ -33,10 +33,12 @@ export const handleErrorResponse: handleErrorResponseType = (
       setValidationErrorMessages(data.messages);
       break;
     case 401:
+      alert(data.message || "エラーが発生しました。");
+      router.push("/auth/signin");
+      break;
     case 403:
     case 404:
       alert(data.message || "エラーが発生しました。");
-      setValidationErrorMessages([]);
       router.push(redirectUrl);
       break;
     case 500:

--- a/frontend/src/pages/404.tsx
+++ b/frontend/src/pages/404.tsx
@@ -1,0 +1,26 @@
+// React & Next.js
+import React from "react";
+
+// MUI
+import { Box, Container, Typography } from "@mui/material";
+
+// CSS
+import styles from "../styles/common.module.css";
+import BackLink from "../../components/BackLink";
+
+const Custom404 = () => {
+  return (
+    <Container component="main" maxWidth="xs">
+      <Box className={styles.container}>
+        <Typography variant="h5" gutterBottom sx={{ margin: "1rem 0" }}>
+          申し訳ありません
+          <br />
+          ページが見つかりません
+        </Typography>
+        <BackLink />
+      </Box>
+    </Container>
+  );
+};
+
+export default Custom404;

--- a/frontend/src/pages/auth/signin.tsx
+++ b/frontend/src/pages/auth/signin.tsx
@@ -4,18 +4,18 @@ import { useRouter } from "next/router";
 
 // state
 import { useRecoilState, useSetRecoilState } from "recoil";
-import errMessagesAtom from "../../recoil/atom/errMessagesAtom";
-import userAtom from "../../recoil/atom/userAtoms";
+import errMessagesAtom from "../../../recoil/atom/errMessagesAtom";
+import userAtom from "../../../recoil/atom/userAtoms";
 
 // library
-import apiClient from "../lib/apiClient";
-import { fetchUser } from "../lib/authHelpers";
-import { handleErrorResponse } from "../lib/errorHandler";
+import apiClient from "../../lib/apiClient";
+import { fetchUser } from "../../lib/authHelpers";
+import { handleErrorResponse } from "../../lib/errorHandler";
 
 // components
-import PageHead from "../../components/PageHead";
-import HomeLink from "../../components/HomeLink";
-import ErrorMessageList from "../../components/ErrorMessageList";
+import PageHead from "../../../components/PageHead";
+import HomeLink from "../../../components/HomeLink";
+import ErrorMessageList from "../../../components/ErrorMessageList";
 
 // MUI
 import Button from "@mui/material/Button";
@@ -25,7 +25,7 @@ import Typography from "@mui/material/Typography";
 import Container from "@mui/material/Container";
 
 // CSS
-import styles from "../styles/common.module.css";
+import styles from "../../styles/common.module.css";
 
 export default function SignIn() {
   const router = useRouter();
@@ -34,7 +34,7 @@ export default function SignIn() {
   const [email, setEmail] = useState<string>();
   const [password, setPassword] = useState<string>();
 
-  // 状態管理
+  // 共有情報
   const setUser = useSetRecoilState(userAtom);
   const [validationErrorMessages, setValidationErrorMessages] =
     useRecoilState(errMessagesAtom);
@@ -49,11 +49,10 @@ export default function SignIn() {
           password,
         })
         .then(() => {
-          fetchUser(setUser);
-          router.push("/");
+          fetchUser(setUser, router);
+          router.push("/mypage");
         })
         .catch((err) => {
-          console.log("type: ", typeof err);
           handleErrorResponse(
             err,
             router,

--- a/frontend/src/pages/auth/signup.tsx
+++ b/frontend/src/pages/auth/signup.tsx
@@ -4,16 +4,16 @@ import { useRouter } from "next/router";
 
 // state
 import { useRecoilState } from "recoil";
-import errMessagesAtom from "../../recoil/atom/errMessagesAtom";
+import errMessagesAtom from "../../../recoil/atom/errMessagesAtom";
 
 // library
-import apiClient from "../lib/apiClient";
-import { handleErrorResponse } from "../lib/errorHandler";
+import apiClient from "../../lib/apiClient";
+import { handleErrorResponse } from "../../lib/errorHandler";
 
 // components
-import PageHead from "../../components/PageHead";
-import HomeLink from "../../components/HomeLink";
-import ErrorMessageList from "../../components/ErrorMessageList";
+import PageHead from "../../../components/PageHead";
+import HomeLink from "../../../components/HomeLink";
+import ErrorMessageList from "../../../components/ErrorMessageList";
 
 // MUI
 import Button from "@mui/material/Button";
@@ -26,7 +26,7 @@ import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 
 // CSS
-import styles from "../styles/common.module.css";
+import styles from "../../styles/common.module.css";
 
 type sexType = "male" | "female";
 
@@ -42,7 +42,7 @@ export default function SignUp() {
   const [sex, setSex] = useState<sexType | "">("");
   const [birthDate, setBirthDate] = useState<Date>(null);
 
-  // 状態管理
+  // 共有情報
   const [validationErrorMessages, setValidationErrorMessages] =
     useRecoilState(errMessagesAtom);
 
@@ -59,7 +59,7 @@ export default function SignUp() {
           sex,
         })
         .then(() => {
-          router.push("/signin");
+          router.push("/auth/signin");
         })
         .catch((err) => {
           handleErrorResponse(

--- a/frontend/src/pages/mypage/index.tsx
+++ b/frontend/src/pages/mypage/index.tsx
@@ -5,32 +5,21 @@ import Link from "next/link";
 
 // state
 import { useRecoilValue } from "recoil";
-import userAtom from "../../recoil/atom/userAtoms";
+import userAtom from "../../../recoil/atom/userAtoms";
 
 // utility
 import { format, differenceInYears } from "date-fns";
 
 // components
-import RemainingLife from "../../components/RemainingLife";
-import PageHead from "../../components/PageHead";
+import RemainingLife from "../../../components/RemainingLife";
+import PageHead from "../../../components/PageHead";
 
 // MUI
-import {
-  Box,
-  Button,
-  Container,
-  FormControl,
-  Grid,
-  InputLabel,
-  MenuItem,
-  Select,
-  Typography,
-} from "@mui/material";
-import { DatePicker } from "@mui/x-date-pickers";
+import { Box, Button, Container, Typography } from "@mui/material";
 import HistoryToggleOffIcon from "@mui/icons-material/HistoryToggleOff";
 
 // CSS
-import styles from "../styles/indexStyle.module.css";
+import styles from "../../styles/indexStyle.module.css";
 
 type sexType = "male" | "female";
 
@@ -128,14 +117,11 @@ export default function Home() {
       </PageHead>
       <Container>
         <Box className={styles.container}>
-          {person && (
+          {user && (
             <>
-              <Link href="/" passHref>
+              <Link href="/mypage/persons" passHref>
                 <Button
-                  component="a"
-                  onClick={handleReset}
                   variant="contained"
-                  style={{ margin: "1rem 0" }}
                   sx={{
                     mt: 3,
                     mb: 2,
@@ -144,13 +130,13 @@ export default function Home() {
                     margin: "1rem 0",
                   }}
                 >
-                  再設定
+                  みんなの余命
                 </Button>
               </Link>
             </>
           )}
 
-          {person ? (
+          {person && (
             <>
               <Box className={styles.infoBox}>
                 <Typography variant="subtitle1">
@@ -189,65 +175,6 @@ export default function Home() {
                 </Typography>
                 <Box className={styles.remainingLife}>
                   <RemainingLife key={remainingLifeKey} person={person} />
-                </Box>
-              </Box>
-            </>
-          ) : (
-            <>
-              <Box className={styles.settingContainer}>
-                <Typography component="h1" variant="h5">
-                  情報を設定して余命を表示しましょう
-                </Typography>
-                <Box
-                  component="form"
-                  noValidate
-                  onSubmit={handleSubmit}
-                  sx={{ mt: 3 }}
-                >
-                  <Grid container spacing={2}>
-                    <Grid item xs={12} sm={8} sx={{ margin: "auto" }}>
-                      <FormControl fullWidth>
-                        <DatePicker
-                          label="生年月日"
-                          onChange={(e: Date) => setSelectBirthDate(e as Date)}
-                          value={selectBirthDate}
-                          maxDate={new Date()}
-                          openTo="year"
-                          views={["year", "month", "day"]}
-                        />
-                      </FormControl>
-                    </Grid>
-                    <Grid item xs={12} sm={4}>
-                      <FormControl fullWidth>
-                        <InputLabel htmlFor="gender">性別</InputLabel>
-                        <Select
-                          value={selectSex}
-                          required
-                          label="性別"
-                          onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                            setSelectSex(e.target.value as sexType)
-                          }
-                        >
-                          <MenuItem value={"male"}>男</MenuItem>
-                          <MenuItem value={"female"}>女</MenuItem>
-                        </Select>
-                      </FormControl>
-                    </Grid>
-                  </Grid>
-
-                  <Button
-                    type="submit"
-                    fullWidth
-                    variant="contained"
-                    sx={{
-                      mt: 3,
-                      mb: 2,
-                      backgroundColor: "#1565C0",
-                      color: "#FFFFFF",
-                    }}
-                  >
-                    設定
-                  </Button>
                 </Box>
               </Box>
             </>

--- a/frontend/src/pages/mypage/persons/[id].tsx
+++ b/frontend/src/pages/mypage/persons/[id].tsx
@@ -4,18 +4,18 @@ import { useRouter } from "next/router";
 
 // state
 import { useRecoilState } from "recoil";
-import userAtom from "../../../recoil/atom/userAtoms";
-import errMessagesAtom from "../../../recoil/atom/errMessagesAtom";
+import userAtom from "../../../../recoil/atom/userAtoms";
+import errMessagesAtom from "../../../../recoil/atom/errMessagesAtom";
 
 // library
-import apiClient from "../../lib/apiClient";
-import { signout } from "../../lib/authHelpers";
-import { handleErrorResponse } from "../../lib/errorHandler";
+import apiClient from "../../../lib/apiClient";
+import { signout } from "../../../lib/authHelpers";
+import { handleErrorResponse } from "../../../lib/errorHandler";
 
 // components
-import BackLink from "../../../components/BackLink";
-import PageHead from "../../../components/PageHead";
-import ErrorMessageList from "../../../components/ErrorMessageList";
+import BackLink from "../../../../components/BackLink";
+import PageHead from "../../../../components/PageHead";
+import ErrorMessageList from "../../../../components/ErrorMessageList";
 
 // MUI
 import {
@@ -33,7 +33,7 @@ import {
 import { DatePicker } from "@mui/x-date-pickers";
 
 // CSS
-import styles from "../../styles/persons/personStyle.module.css";
+import styles from "../../../styles/persons/personStyle.module.css";
 
 type sexType = "male" | "female";
 
@@ -74,7 +74,7 @@ const PersonPage = ({ person }) => {
   const [sex, setSex] = useState<sexType | "">("");
   const [birthDate, setBirthDate] = useState<Date>(null);
 
-  // 状態管理
+  // 共有情報
   const [user, setUser] = useRecoilState(userAtom);
   const [validationErrorMessages, setValidationErrorMessages] =
     useRecoilState(errMessagesAtom);
@@ -92,13 +92,13 @@ const PersonPage = ({ person }) => {
         })
         .then((res) => {
           alert(res.data.message);
-          router.push("/persons");
+          router.back();
         })
         .catch((err) => {
           handleErrorResponse(
             err,
             router,
-            "/persons",
+            "/mypage/persons",
             setValidationErrorMessages,
           );
         });
@@ -118,7 +118,7 @@ const PersonPage = ({ person }) => {
           })
           .then((res) => {
             alert(res.data.message);
-            router.push("/persons");
+            router.back();
           })
           .catch((err) => {
             handleErrorResponse(
@@ -143,14 +143,9 @@ const PersonPage = ({ person }) => {
     } else {
       // 人物情報が利用できない場合の処理
       alert("人物情報を取得できませんでした");
-      router.push("/persons");
+      router.back();
     }
   }, []);
-
-  const redirectToLogin = () => {
-    signout(setUser);
-    router.push("/signin");
-  };
 
   return (
     <>
@@ -257,7 +252,7 @@ const PersonPage = ({ person }) => {
           </Container>
         </>
       ) : (
-        redirectToLogin()
+        router.back()
       )}
     </>
   );

--- a/frontend/src/pages/mypage/persons/create.tsx
+++ b/frontend/src/pages/mypage/persons/create.tsx
@@ -4,18 +4,18 @@ import { useRouter } from "next/router";
 
 // state
 import { useRecoilState, useRecoilValue } from "recoil";
-import userAtom from "../../../recoil/atom/userAtoms";
-import errMessagesAtom from "../../../recoil/atom/errMessagesAtom";
+import userAtom from "../../../../recoil/atom/userAtoms";
+import errMessagesAtom from "../../../../recoil/atom/errMessagesAtom";
 
 // library
-import apiClient from "../../lib/apiClient";
-import { handleErrorResponse } from "../../lib/errorHandler";
+import apiClient from "../../../lib/apiClient";
+import { handleErrorResponse } from "../../../lib/errorHandler";
 
 // components
-import BackLink from "../../../components/BackLink";
-import PageHead from "../../../components/PageHead";
-import ProtectRoute from "../../../components/ProtectRoute";
-import ErrorMessageList from "../../../components/ErrorMessageList";
+import BackLink from "../../../../components/BackLink";
+import PageHead from "../../../../components/PageHead";
+import ProtectRoute from "../../../../components/ProtectRoute";
+import ErrorMessageList from "../../../../components/ErrorMessageList";
 
 // MUI
 import {
@@ -33,7 +33,7 @@ import {
 import { DatePicker } from "@mui/x-date-pickers";
 
 // CSS
-import styles from "../../styles/persons/createStyle.module.css";
+import styles from "../../../styles/persons/createStyle.module.css";
 
 type sexType = "male" | "female";
 
@@ -45,27 +45,10 @@ const CreatePersonData = () => {
   const [sex, setSex] = useState<sexType | "">("");
   const [birthDate, setBirthDate] = useState<Date>(null);
 
-  // 状態管理
+  // 共有情報
   const user = useRecoilValue(userAtom);
   const [validationErrorMessages, setValidationErrorMessages] =
     useRecoilState(errMessagesAtom);
-
-  // 登録件数を確認
-  /* eslint-disable react-hooks/exhaustive-deps */
-  useEffect(() => {
-    const getPersonsCount = async () => {
-      await apiClient.get("/persons/findAllCount").catch((err) => {
-        handleErrorResponse(
-          err,
-          router,
-          "/persons",
-          setValidationErrorMessages,
-        );
-      });
-    };
-
-    getPersonsCount();
-  }, []);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -80,13 +63,13 @@ const CreatePersonData = () => {
           userId: user.id,
         })
         .then(() => {
-          router.push("/persons");
+          router.push("/mypage/persons");
         })
         .catch((err) => {
           handleErrorResponse(
             err,
             router,
-            "/persons",
+            "/mypage/persons",
             setValidationErrorMessages,
           );
         });
@@ -94,6 +77,23 @@ const CreatePersonData = () => {
       alert("予期しないエラーが発生しました。\nもう一度やり直してください。");
     }
   };
+
+  // 登録件数を確認
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    const getPersonsCount = async () => {
+      await apiClient.get("/persons/checkCount").catch((err) => {
+        return handleErrorResponse(
+          err,
+          router,
+          "/mypage/persons",
+          setValidationErrorMessages,
+        );
+      });
+    };
+
+    getPersonsCount();
+  }, []);
 
   return (
     <>

--- a/frontend/src/pages/mypage/persons/index.tsx
+++ b/frontend/src/pages/mypage/persons/index.tsx
@@ -4,19 +4,19 @@ import Link from "next/link";
 
 // state
 import { useRecoilValue } from "recoil";
-import userAtom from "../../../recoil/atom/userAtoms";
+import userAtom from "../../../../recoil/atom/userAtoms";
 
 // utility
 import { format } from "date-fns";
 
 // library
-import apiClient from "../../lib/apiClient";
+import apiClient from "../../../lib/apiClient";
 
 // components
-import RemainingLife from "../../../components/RemainingLife";
-import BackLink from "../../../components/BackLink";
-import PageHead from "../../../components/PageHead";
-import ProtectRoute from "../../../components/ProtectRoute";
+import RemainingLife from "../../../../components/RemainingLife";
+import BackLink from "../../../../components/BackLink";
+import PageHead from "../../../../components/PageHead";
+import ProtectRoute from "../../../../components/ProtectRoute";
 
 // MUI
 import {
@@ -41,7 +41,7 @@ const Persons = () => {
   // 人物情報
   const [persons, setPersons] = useState<personData[]>();
 
-  // 状態管理
+  // 共有情報
   const user = useRecoilValue(userAtom);
 
   // ソート設定
@@ -115,7 +115,6 @@ const Persons = () => {
       width: 200,
       flex: 0.3,
       renderCell: (params: GridRenderCellParams<any>) => (
-        // <RemainingLife person={person:{sex: ...params.row.sex,birthDate: ...params.row.birthDate} } />
         <RemainingLife
           person={{ sex: params.row.sex, birthDate: params.row.birthDate }}
         />
@@ -131,7 +130,7 @@ const Persons = () => {
       flex: 0.3,
       renderCell: (params: GridRenderCellParams<any>) => (
         <>
-          <Link className="text-blue-400" href={`/persons/${params.id}`}>
+          <Link className="text-blue-400" href={`/mypage/persons/${params.id}`}>
             編集
           </Link>
         </>
@@ -148,7 +147,7 @@ const Persons = () => {
         {persons && (
           <Container maxWidth="md">
             <Box>
-              <Link href="/persons/create">
+              <Link href="/mypage/persons/create">
                 <Button
                   variant="contained"
                   sx={{

--- a/frontend/src/pages/mypage/setting/index.tsx
+++ b/frontend/src/pages/mypage/setting/index.tsx
@@ -4,19 +4,19 @@ import { useRouter } from "next/router";
 
 // state
 import { useRecoilState } from "recoil";
-import userAtom from "../../recoil/atom/userAtoms";
-import errMessagesAtom from "../../recoil/atom/errMessagesAtom";
+import userAtom from "../../../../recoil/atom/userAtoms";
+import errMessagesAtom from "../../../../recoil/atom/errMessagesAtom";
 
 // library
-import apiClient from "../lib/apiClient";
-import { signout } from "../lib/authHelpers";
-import { handleErrorResponse } from "../lib/errorHandler";
+import apiClient from "../../../lib/apiClient";
+import { signout } from "../../../lib/authHelpers";
+import { handleErrorResponse } from "../../../lib/errorHandler";
 
 // components
-import BackLink from "../../components/BackLink";
-import PageHead from "../../components/PageHead";
-import ProtectRoute from "../../components/ProtectRoute";
-import ErrorMessageList from "../../components/ErrorMessageList";
+import BackLink from "../../../../components/BackLink";
+import PageHead from "../../../../components/PageHead";
+import ProtectRoute from "../../../../components/ProtectRoute";
+import ErrorMessageList from "../../../../components/ErrorMessageList";
 
 // MUI
 import {
@@ -30,16 +30,16 @@ import {
 } from "@mui/material";
 
 // CSS
-import styles from "../styles/common.module.css";
+import styles from "../../../styles/common.module.css";
 
-const MyPage = () => {
+const Setting = () => {
   const router = useRouter();
 
   // アカウント情報
   const [email, setEmail] = useState<string>("");
   const [password, setPassword] = useState<string | null>("");
 
-  // 状態管理
+  // 共有情報
   const [user, setUser] = useRecoilState(userAtom);
   const [validationErrorMessages, setValidationErrorMessages] =
     useRecoilState(errMessagesAtom);
@@ -56,7 +56,7 @@ const MyPage = () => {
         })
         .then((res) => {
           alert(res.data.message);
-          router.push("/");
+          router.back();
         })
         .catch((err) => {
           handleErrorResponse(
@@ -84,8 +84,7 @@ const MyPage = () => {
           })
           .then(() => {
             alert("ユーザアカウトを削除しました");
-            signout(setUser);
-            router.push("/");
+            signout(setUser, router);
           })
           .catch((err) => {
             if (err.response.status === 500) {
@@ -184,4 +183,4 @@ const MyPage = () => {
   );
 };
 
-export default MyPage;
+export default Setting;


### PR DESCRIPTION
#51 
## 内容
 - 404エラー取得時の画面を作成。
 - トップページを非ログイン時のみの表示にして、ログイン時の画面は別に作成。
 - frontendのフォルダ構成を以下の通りに変更
```変更後
.
├── README.md
├── components
│   ├── BackLink.tsx
│   ├── ClearErrorMessages.tsx
│   ├── ErrorMessageList.tsx
│   ├── HomeLink.tsx
│   ├── Navbar.tsx
│   ├── PageHead.tsx
│   ├── ProtectPersonPage.tsx
│   ├── ProtectRoute.tsx
│   └── RemainingLife.tsx
├── next-env.d.ts
├── next.config.js
├── package-lock.json
├── package.json
├── public
│   ├── favicon.ico
│   └── logo.png
├── recoil
│   └── atom
│       ├── errMessagesAtom.ts
│       └── userAtoms.ts
├── src
│   ├── context
│   │   └── auth.tsx
│   ├── lib
│   │   ├── apiClient.ts
│   │   ├── authHelpers.ts
│   │   └── errorHandler.ts
│   ├── pages
│   │   ├── 404.tsx
│   │   ├── _app.tsx
│   │   ├── _document.tsx
│   │   ├── api
│   │   │   └── hello.ts
│   │   ├── auth
│   │   │   ├── signin.tsx
│   │   │   └── signup.tsx
│   │   ├── index.tsx
│   │   └── mypage
│   │       ├── index.tsx
│   │       ├── persons
│   │       │   ├── [id].tsx
│   │       │   ├── create.tsx
│   │       │   └── index.tsx
│   │       └── setting
│   │           └── index.tsx
│   └── styles
│       ├── common.module.css
│       ├── components
│       │   └── NavbarStyle.module.css
│       ├── context
│       │   └── authStyle.module.css
│       ├── indexStyle.module.css
│       └── persons
│           ├── createStyle.module.css
│           └── personStyle.module.css
└── tsconfig.json
```