### PR TITLE
singin関数のエラーハンドリングを別ファイルに分割

### DIFF
--- a/frontend/src/lib/authHelpers.ts
+++ b/frontend/src/lib/authHelpers.ts
@@ -1,6 +1,26 @@
-import apiClient from "./apiClient";
+// React & Next.js
+import { NextRouter } from "next/router";
 
-export const fetchUser = async (setUser, router) => {
+// state
+import { SetterOrUpdater } from "recoil";
+
+// library
+import apiClient from "./apiClient";
+import { handleErrorResponse } from "./errorHandler";
+
+type userType = null | {
+  id: number;
+  username: string;
+  email: string;
+  sex: string;
+  birthDate: string;
+};
+
+export const fetchUser = async (
+  setUser: SetterOrUpdater<userType>,
+  setValidationErrorMessages: SetterOrUpdater<string[]>,
+  router: NextRouter
+) => {
   try {
     // サインイン時、ユーザーをセット
     apiClient
@@ -9,25 +29,17 @@ export const fetchUser = async (setUser, router) => {
         setUser(res.data.user);
       })
       .catch((err) => {
-        handleErrorResponse(err);
+        handleErrorResponse(
+          err,
+          router,
+          router.asPath,
+          setValidationErrorMessages
+        );
         signout(setUser, router);
       });
   } catch (err) {
     alert("予期しないエラーが発生しました\nもう一度やり直してください");
     signout(setUser, router);
-  }
-};
-
-const handleErrorResponse = (err) => {
-  switch (err.response.status) {
-    case 500:
-      alert("サーバで問題が発生しました\nもう一度やり直してください");
-      break;
-    case 404:
-      alert(err.response.data.message);
-      break;
-    default:
-      alert("予期しないエラーが発生しました\nもう一度やり直してください");
   }
 };
 

--- a/frontend/src/pages/auth/signin.tsx
+++ b/frontend/src/pages/auth/signin.tsx
@@ -49,7 +49,7 @@ export default function SignIn() {
           password,
         })
         .then(() => {
-          fetchUser(setUser, router);
+          fetchUser(setUser, setValidationErrorMessages, router);
           router.push("/mypage");
         })
         .catch((err) => {
@@ -57,7 +57,7 @@ export default function SignIn() {
             err,
             router,
             router.asPath,
-            setValidationErrorMessages,
+            setValidationErrorMessages
           );
         });
     } catch (error) {


### PR DESCRIPTION
#53 
## 内容
 - singin関数のエラーハンドリングをfrontend\src\lib\authHelpers.tsに分割
 - singin関数の仮引数に型を追加